### PR TITLE
chore: add encoding= to open() and type hints in main.py and utils.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ hongkong_timezone = pytz.timezone('HongKong')
 current_date = datetime.now(hongkong_timezone).strftime("%Y-%m-%d")
 
 # get last update date from README.md
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
     while True:
         line = f.readline()
         if "Last update:" in line: break

--- a/utils.py
+++ b/utils.py
@@ -55,7 +55,7 @@ def request_github_trending_repos(max_results: int,days: int = 7) -> List[Dict[s
     return repos
 
 ## Using Google Translate, maybe later do translation on the repos' summary
-def translate_text(text, target_language='zh-HK'):
+def translate_text(text: str, target_language: str='zh-HK') -> str:
     """
     A simple function to translate text using a free translation API.
     You may need to replace this with a more reliable service.
@@ -119,23 +119,24 @@ def generate_table(repos: List[Dict[str, str]], column_names: List[str] = [], ig
     return header + "\n" + separator + "\n" + "\n".join(rows)
 
 
-def back_up_files():
+def back_up_files() -> None:
     # back up README.md and ISSUE_TEMPLATE.md
     shutil.move("README.md", "README.md.bk")
     shutil.move(".github/ISSUE_TEMPLATE.md", ".github/ISSUE_TEMPLATE.md.bk")
 
-def restore_files():
+def restore_files() -> None:
     # restore README.md and ISSUE_TEMPLATE.md
     shutil.move("README.md.bk", "README.md")
     shutil.move(".github/ISSUE_TEMPLATE.md.bk", ".github/ISSUE_TEMPLATE.md")
 
-def remove_backups():
+def remove_backups() -> None:
     # remove README.md and ISSUE_TEMPLATE.md
     os.remove("README.md.bk")
     os.remove(".github/ISSUE_TEMPLATE.md.bk")
 
 def get_daily_date():
     # get hongkong time in the format of "March 1, 2021"
+    # TODO: add type annotations for parameters/return type
     hongkong_timezone = pytz.timezone('HongKong')
     today = datetime.now(hongkong_timezone)
     return today.strftime("%B %d, %Y")


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be made a bit more robust and readable. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Explicit encoding for file operations
- `main.py`: added `encoding="utf-8"` to 1 `open()` call(s)

I added explicit encoding here because Python's default behavior depends on the operating system. This change ensures the code handles text consistently whether it is running on Windows, Linux, or macOS, preventing potential UnicodeDecodeErrors.

### Type hint additions
- `utils.py`: added type hints to 4 function(s) and left 1 `# TODO` comments where types were unclear

I have added basic type annotations based on variable names and default values. This should make the code easier to work with in modern IDEs without changing any of the actual logic.

### Examples of changes
**Example change in `main.py`:**
```diff
-with open("README.md", "r") as f:
+with open("README.md", "r", encoding="utf-8") as f:
```

**Example change in `utils.py`:**
```diff
-def translate_text(text, target_language='zh-HK'):
+def translate_text(text: str, target_language: str='zh-HK') -> str:
-def back_up_files():
+def back_up_files() -> None:
-def restore_files():
+def restore_files() -> None:
-def remove_backups():
+def remove_backups() -> None:
+    # TODO: add type annotations for parameters/return type
```

---

### Safety and verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- Files using dynamic patterns like `eval()` or `globals()` were automatically skipped.
- I did not modify any `__init__.py` files.

If any of these annotations look off to you, feel free to adjust them or close the PR entirely.